### PR TITLE
Validate version argument (fix NA crash)

### DIFF
--- a/R/gmd.R
+++ b/R/gmd.R
@@ -256,6 +256,14 @@ gmd <- function(variables = NULL, country = NULL, version = NULL,
   # ============================================================================
   # Version check (S3 first, GitHub fallback)
   # ============================================================================
+
+  # Reject NA / non-character version early so it doesn't propagate into
+  # `tolower(version) == "list"` below (which would error with the cryptic
+  # "missing value where TRUE/FALSE needed")
+  if (!is.null(version) && (!is.character(version) || length(version) != 1 || is.na(version))) {
+    stop("`version` must be a single non-NA string (e.g. \"2025_09\"), \"current\", or \"list\".")
+  }
+
   versions_df <- .gmd_load_versions_df()
   available_versions <- sort(unique(versions_df$versions), decreasing = TRUE)
   current_version <- available_versions[1]


### PR DESCRIPTION
Tracked upstream at [Global-Macro-Database-Internal#413](https://github.com/KMueller-Lab/Global-Macro-Database-Internal/issues/413). Same filter applied to the recent Stata PR: fix actual bugs, skip nice-to-haves.

## Bug

`gmd(version = NA)` crashed with the cryptic R-level error `"missing value where TRUE/FALSE needed"`. Root cause at [`R/gmd.R:263`](https://github.com/KMueller-Lab/Global-Macro-Database-R/blob/main/R/gmd.R#L263):

```r
if (!is.null(version) && tolower(version) == "list") { ... }
```

With `version = NA`, `tolower(NA)` returns `NA`, `NA == "list"` returns `NA`, and `if (NA)` is an error. Same failure mode for `version = 2025` (numeric) or a multi-element character vector.

## Fix

Reject those inputs at the top of the version-check block with a clear message that names the argument.

## Verified

```r
> gmd(version = NA,               country = "USA", variables = "rGDP")
Error: `version` must be a single non-NA string (e.g. "2025_09"), "current", or "list".
> gmd(version = NA_character_,    country = "USA", variables = "rGDP")
Error: `version` must be a single non-NA string (e.g. "2025_09"), "current", or "list".
> gmd(version = c("2025_09","2026_03"), country = "USA", variables = "rGDP")
Error: `version` must be a single non-NA string (...).
> gmd(version = 2025,             country = "USA", variables = "rGDP")
Error: `version` must be a single non-NA string (...).

# Regressions — all still work:
> gmd(version = "2025_09", country = "USA", variables = "rGDP")   # 242 rows
> gmd(version = "current", country = "USA", variables = "rGDP")   # 241 rows
> gmd(version = "list")                                            # prints list
> gmd(country = "USA", variables = "rGDP")                         # 241 rows (NULL default)
```

## Out of scope

Other issues catalogued in #413 (double "Error:" prefix, case-sensitivity inconsistency across country/variables/sources, `iso=TRUE` warning vs error, empty-vector handling, dependency cleanup, `start_year`/`end_year` not implemented) are UX/consistency issues rather than functional bugs, kept for separate PRs.

Also note: the listed-but-404 versions on S3 (`2025_01/03/05/06/08`) are a release-pipeline issue and not fixable here.